### PR TITLE
feat(SCSS): Adding 'Bulma' SCSS framework to sass-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2750,6 +2750,11 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "bulma": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.1.tgz",
+      "integrity": "sha512-wRSO2LXB+qI9Pyz2id+uZr4quz5aftSN7Ay1ysr1+krzVp3utD+Ci4CeKuZdrYGc800t65b7heXBL6qw2Wo/lQ=="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:e2e": "vue-cli-service test:e2e"
   },
   "dependencies": {
+    "bulma": "^0.7.1",
     "vue": "^2.5.16",
     "vue-class-component": "^6.0.0",
     "vue-property-decorator": "^6.0.0",

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,6 +1,20 @@
 <template>
   <div class="hello">
     <h1>{{ msg }}</h1>
+    <div class="columns">
+  <div class="column">
+    First column
+  </div>
+  <div class="column">
+    Second column
+  </div>
+  <div class="column">
+    Third column
+  </div>
+  <div class="column">
+    Fourth column
+  </div>
+</div>
     <p>
       For guide and recipes on how to configure / customize this project,<br>
       check out the

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import App from './App.vue';
 import router from './router';
 import store from './store';
+import './styles/main.scss';
 
 Vue.config.productionTip = false;
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,0 +1,4 @@
+//@import 'sass/utilities/all';
+
+
+@import 'bulma';

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,29 @@
+function updateScssIncludePaths(options) {
+    options.includePaths = options.includePaths || [];
+    options.includePaths.push('node_modules/bulma');
+    return options;
+}
+module.exports = {
+    chainWebpack: config => {
+        config.module
+            .rule('scss')
+            .oneOf('vue')
+            .use('sass-loader')
+            .tap(updateScssIncludePaths);
+        config.module
+            .rule('scss')
+            .oneOf('normal')
+            .use('sass-loader')
+            .tap(updateScssIncludePaths);
+        config.module
+            .rule('sass')
+            .oneOf('vue')
+            .use('sass-loader')
+            .tap(updateScssIncludePaths);
+        config.module
+            .rule('sass')
+            .oneOf('normal')
+            .use('sass-loader')
+            .tap(updateScssIncludePaths);
+    }
+  }


### PR DESCRIPTION
By adding a `vue.config.js` file, I was able to configure the `sass-loader` option to add the path to the Bulma SCSS library to the `includePaths`.

This enables us to `@import` Bulma scss files into our source files.

This addresses Issue #1 